### PR TITLE
GA Updates

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -47,9 +47,9 @@
     });
     ga('send', {
       hitType: 'event',
-      eventCategory: 'Download',
+      eventCategory: $(this).attr("data-response"),
       eventAction: 'click',
-      eventLabel: $(this).attr("data-response")
+      eventLabel: window.location.href
     });
     gtag('event', 'click', {
       'event_category': $(this).attr("data-response"),


### PR DESCRIPTION
This PR changes the event action when a user clicks on a tutorial download/view option. This PR changes the event from "Download" to the option clicked eg. "Run in Google Colab" with the tutorial URL being the event label.